### PR TITLE
Hard-coded marker shapes.

### DIFF
--- a/src/bind.py
+++ b/src/bind.py
@@ -23,7 +23,7 @@ def cropAll(root):
   imageList = findImages(root)
   for image in imageList:
     imageOut = re.sub(r'(.[jJ][pP][eE]?[gG])$', '.jpg', image)
-    os.system("python crop.py " + os.path.join(root, image) + " " + os.path.join(root, "cropped", imageOut))
+    os.system("python2 crop.py " + os.path.join(root, image) + " " + os.path.join(root, "cropped", imageOut))
 
 # Bind cropped files into a PDF
 def bindAll(root):

--- a/src/crop.py
+++ b/src/crop.py
@@ -1,13 +1,14 @@
 import cv2
 import cv2.aruco as aruco
 import sys, math
+from make_markers import createDict
 
 MARKER_EVEN_SIDE = 0
 MARKER_EVEN_TOP = 1
 MARKER_ODD_SIDE = 2
 MARKER_ODD_TOP = 3
 
-markerDictionary = aruco.Dictionary_create(4, 5)
+markerDictionary = createDict()
 
 borderWidth = 85
 

--- a/src/make-markers.py
+++ b/src/make-markers.py
@@ -1,9 +1,0 @@
-import numpy as np
-import cv2
-import cv2.aruco as aruco
- 
- 
-markers = aruco.Dictionary_create(4, 5)
-for i in xrange(0, 4):
-  img = aruco.drawMarker(markers, i, 800)
-  cv2.imwrite("markers/marker-" + str(i) + ".png", img)

--- a/src/make_markers.py
+++ b/src/make_markers.py
@@ -1,0 +1,46 @@
+import numpy as np
+import cv2
+import cv2.aruco as aruco
+
+# marker bit arrays
+bit_arrays = np.array([
+			    	   # marker-0
+					   [[1, 0, 1, 1, 0],
+   					    [1, 0, 0, 0, 1],
+   					    [0, 0, 1, 1, 0],
+   					    [1, 1, 1, 1, 0],
+   					    [1, 0, 1, 0, 0]],
+   					   # marker-1
+   					   [[1, 0, 0, 0, 0],
+   					    [0, 0, 0, 0, 0],
+   					    [0, 1, 0, 1, 1],
+   					    [1, 0, 1, 1, 1],
+   					    [0, 1, 1, 1, 1]],
+   					   # marker-2
+   					   [[1, 1, 1, 0, 0],
+   					    [0, 1, 1, 1, 1],
+   					    [1, 0, 0, 0, 0],
+   					    [0, 1, 1, 1, 1],
+   					    [1, 1, 1, 1, 0]],
+   					   # marker-3
+   					   [[0, 0, 0, 0, 0],
+   					    [1, 0, 0, 1, 1],
+   					    [0, 1, 1, 0, 0],
+   					    [0, 1, 1, 0, 0],
+   					    [0, 0, 0, 1, 1]]
+   				      ], dtype='uint8')
+
+def createDict():
+	# creates dictionary of markers based on marker bit arrays
+	markers = aruco.Dictionary_create(bit_arrays.shape[0], bit_arrays.shape[1])
+	byte_arrays = []
+	for array in bit_arrays:
+		byte_arrays.append(aruco.Dictionary_getByteListFromBits(array))
+	bytesList = np.concatenate(byte_arrays, 0)
+	markers.bytesList = bytesList
+	return markers
+ 
+markers = createDict()
+for i in xrange(0, 4):
+  img = aruco.drawMarker(markers, i, 800)
+  cv2.imwrite("markers/marker-" + str(i) + ".png", img)


### PR DESCRIPTION
Aruco seems to have changed and now markers that are returned with aruco.Dictionary_create are no longer those which were included in the Marker Label Sheet.
One alternative may be that the user generates and prints his/her own markers each time, but this is cumbersome.
Instead, I hardcoded the marker shapes in the make-marker script (which name I had to change to make_marker to be able to import it as a module).
Unfortunately, as the Dictionary class constructor doesn't seem to have been ported into Python, I had to work it around by creating a marker dictionary and then replacing its bytesList property (see code).
This may not be the best solution nor the cleanest, but it was the best I could think of and it let me keep working with pictures I already had with the previous markers.