### PR TITLE
crop imported as module in bind instead of running as script

### DIFF
--- a/src/bind.py
+++ b/src/bind.py
@@ -1,4 +1,5 @@
 import os, sys, re
+from crop import crop
 
 # Create the directories in the target path to contain the cropped pages and bound pdf
 def makeDirs(root):
@@ -23,7 +24,7 @@ def cropAll(root):
   imageList = findImages(root)
   for image in imageList:
     imageOut = re.sub(r'(.[jJ][pP][eE]?[gG])$', '.jpg', image)
-    os.system("python2 crop.py " + os.path.join(root, image) + " " + os.path.join(root, "cropped", imageOut))
+    crop(os.path.join(root, image), os.path.join(root, "cropped", imageOut))
 
 # Bind cropped files into a PDF
 def bindAll(root):

--- a/src/crop.py
+++ b/src/crop.py
@@ -136,6 +136,11 @@ def processTopBottom(topBottom):
   bottomBorder = min(bottom[0][1], bottom[1][1]) - borderWidth
   return int(topBorder), int(bottomBorder)
 
+def crop(inFile, outFile):
+  image = cv2.imread(inFile)
+  result = process(image)
+  cv2.imwrite(outFile, result)
+
 def main():
   if len(sys.argv) != 3:
     sys.stderr.write("Usage: crop <infile> <outfile>\n")
@@ -143,8 +148,7 @@ def main():
   else:
     inFile = sys.argv[1]
     outFile = sys.argv[2]
-    image = cv2.imread(inFile)
-    result = process(image)
-    cv2.imwrite(outFile, result)
+    crop(inFile, outFile)
 
-main()
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Bind script was running crop script as system command os.system("python crop... and then two problems arised: (1) it failed if the user's default python version was v3 (as crop must be run with python2), and (2) it failed if the script was run from a directory other than repository's src.
This pull request includes modifications in both bind and crop script in order to use crop as a module inside bind, instead.
Checked both crop and bind and they seemed to be working correctly.